### PR TITLE
Recommend Screen Fixes + Android Dependencies

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -140,15 +140,6 @@ dependencies {
     compile project(':react-native-youtube')
     compile project(':react-native-video')
     compile project(':react-native-vector-icons')
-    compile project(':react-native-youtube')
-    compile project(':react-native-video')
-    compile project(':react-native-vector-icons')
-    compile project(':react-native-video')
-    compile project(':react-native-vector-icons')
-    compile project(':react-native-video')
-    compile project(':react-native-video')
-    compile project(':react-native-vector-icons')
-    compile project(':react-native-video')
     compile fileTree(dir: "libs", include: ["*.jar"])
     compile "com.android.support:appcompat-v7:23.0.1"
     compile "com.facebook.react:react-native:+"  // From node_modules

--- a/android/app/src/main/java/com/knapsack/MainApplication.java
+++ b/android/app/src/main/java/com/knapsack/MainApplication.java
@@ -6,15 +6,6 @@ import com.facebook.react.ReactApplication;
 import com.inprogress.reactnativeyoutube.ReactNativeYouTube;
 import com.brentvatne.react.ReactVideoPackage;
 import com.oblador.vectoricons.VectorIconsPackage;
-import com.inprogress.reactnativeyoutube.ReactNativeYouTube;
-import com.brentvatne.react.ReactVideoPackage;
-import com.oblador.vectoricons.VectorIconsPackage;
-import com.brentvatne.react.ReactVideoPackage;
-import com.oblador.vectoricons.VectorIconsPackage;
-import com.brentvatne.react.ReactVideoPackage;
-import com.brentvatne.react.ReactVideoPackage;
-import com.oblador.vectoricons.VectorIconsPackage;
-import com.brentvatne.react.ReactVideoPackage;
 import com.facebook.react.ReactNativeHost;
 import com.facebook.react.ReactPackage;
 import com.facebook.react.shell.MainReactPackage;
@@ -37,16 +28,7 @@ public class MainApplication extends Application implements ReactApplication {
           new MainReactPackage(),
             new ReactNativeYouTube(),
             new ReactVideoPackage(),
-            new VectorIconsPackage(),
-            new ReactNativeYouTube(),
-            new ReactVideoPackage(),
-            new VectorIconsPackage(),
-            new ReactVideoPackage(),
-            new VectorIconsPackage(),
-            new ReactVideoPackage(),
-            new ReactVideoPackage(),
-            new VectorIconsPackage(),
-            new ReactVideoPackage()
+            new VectorIconsPackage()
       );
     }
 

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -5,23 +5,5 @@ include ':react-native-video'
 project(':react-native-video').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-video/android')
 include ':react-native-vector-icons'
 project(':react-native-vector-icons').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-vector-icons/android')
-include ':react-native-youtube'
-project(':react-native-youtube').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-youtube/android')
-include ':react-native-video'
-project(':react-native-video').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-video/android')
-include ':react-native-vector-icons'
-project(':react-native-vector-icons').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-vector-icons/android')
-include ':react-native-video'
-project(':react-native-video').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-video/android')
-include ':react-native-vector-icons'
-project(':react-native-vector-icons').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-vector-icons/android')
-include ':react-native-video'
-project(':react-native-video').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-video/android')
-include ':react-native-video'
-project(':react-native-video').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-video/android')
-include ':react-native-vector-icons'
-project(':react-native-vector-icons').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-vector-icons/android')
-include ':react-native-video'
-project(':react-native-video').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-video/android')
 
 include ':app'

--- a/src/components/RecommendDetail.js
+++ b/src/components/RecommendDetail.js
@@ -13,6 +13,7 @@ class RecommendDetail extends Component {
       videoId: props.video.id.videoId
     };
     this.saveVideo = this.saveVideo.bind(this);
+    this.playVideo = this.playVideo.bind(this);
   }
 
   saveVideo() {
@@ -24,6 +25,10 @@ class RecommendDetail extends Component {
           videoId: this.state.videoId
         })
       .then(console.log(`save to user id ${currentUser.uid} with key value ${this.state.videoId}`));
+  }
+
+  playVideo() {
+    Actions.videoViewer({ videoId: this.state.videoId });
   }
 
   render() {
@@ -48,8 +53,8 @@ class RecommendDetail extends Component {
         <CardSection>
 
           <Button
-            accessibilityLabel={'Click to log in!'}
-            onPress={() => Actions.videoViewer({ videoId: this.state.videoId })}
+            accessibilityLabel={'Click to play!'}
+            onPress={this.playVideo}
             style={{ backgroundColor: 'red' }}
             accessible
           >
@@ -58,7 +63,7 @@ class RecommendDetail extends Component {
 
           <Button
             accessibilityLabel={'Click to Save!'}
-            onPress={() => this.saveVideo()}
+            onPress={this.saveVideo}
             style={{ backgroundColor: '#57d1c9' }}
             accessible
           >

--- a/src/components/VideoViewer.js
+++ b/src/components/VideoViewer.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import { View } from 'react-native';
 import YouTube from 'react-native-youtube';
+import API_KEY from '../../config/YoutubeAPI';
 
 class VideoViewer extends Component {
   constructor(props) {
@@ -18,6 +19,7 @@ class VideoViewer extends Component {
 
         <YouTube
           ref={(component) => { this.youTubePlayer = component; }}
+          apiKey={API_KEY}
           videoId={this.state.videoId}
           play
           fullscreen


### PR DESCRIPTION
This addresses issues in navbar PR which belongs in recommend_screen branch:
-Fixed error on Android that wasn't letting videos load through recommend screen
-Added API key to Youtube prop(also why videos weren't loading)
-Removed arrow props in video viewer file
